### PR TITLE
Remove unused packages

### DIFF
--- a/lib/maid_llm.dart
+++ b/lib/maid_llm.dart
@@ -5,5 +5,3 @@ export 'src/chat_node_tree.dart';
 export 'src/sampling_params.dart';
 export 'src/gpt_params.dart';
 export 'src/maid_llm.dart';
-
-export 'package:langchain/langchain.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  langchain: ^0.4.1 # for using ChatMessage classes
 
 dev_dependencies:
   ffigen: ^11.0.0


### PR DESCRIPTION
Removes `langchain` as it is not used in the package.

cc @danemadsen 